### PR TITLE
Fixed survivor jury number points

### DIFF
--- a/survive/models.py
+++ b/survive/models.py
@@ -109,9 +109,9 @@ class Season(models.Model):
         """Returns one more than the highest jury number of all eliminated Survivors. 0 if no Survivors eliminated yet."""
         highest_jury_number = 0
         winner = False
-        fresh_season = True # true if no survivors have been eliminated yet, in which case, jury number should be 0
+        fresh_season = True # until a Survivor has been eliminated with a non-zero jury number, we don't begin incrementing the jury number
         for s in self.survivor_set.all():
-            if fresh_season and not s.status:
+            if fresh_season and not s.status and s.jury_number > 0:
                 fresh_season = False
             if not s.status and s.jury_number > highest_jury_number:
                 highest_jury_number = s.jury_number

--- a/survive/tests.py
+++ b/survive/tests.py
@@ -125,7 +125,25 @@ class SurvivorTestCase(TestCase):
             winner = False
         )
 
-        self.assertEqual(survivor.points()[0], 1) # now that a survivor has been eliminated, jury_number should be 1, so should have 1 point
+        self.assertEqual(survivor.points()[0], 0) # survivor3 has been eliminated, but their jury number was 0, so jury_number points should still be 0
+
+        survivor4 = Survivor.objects.create( # this is a 'base' Survivor, fresh off the boat, no points earned
+            season = season,
+            team = team,
+            name = "Test Player4",
+            status = False, # this survivor has been eliminated
+            idols = 0,
+            advantages = 0,
+            immunities = 0,
+            jury_number = 1,
+            confessionals = 0,
+            fan_favorite = False,
+            finalist = False,
+            winner = False
+        )
+
+        self.assertEqual(survivor.points()[0], 2) # survivor4 has been eliminated, & their jury number was 1 (nonzero), so jury_number points should be 2
+
 
     def test_points_sum_comparisons_no_ties(self):
         """Survivor points sum correctly. This tests whether points calq correctly when determining 'most of' awards. No ties here"""


### PR DESCRIPTION
Fixed jury number points awarded before
an eliminated survivor has earned jury number points